### PR TITLE
feat: Core UI primitives — PixelBorder, GlassCard, SectionHeading, SectionWrapper

### DIFF
--- a/src/components/layout/SectionHeading.tsx
+++ b/src/components/layout/SectionHeading.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { motion } from "motion/react";
+import { cn } from "@/lib/cn";
+import { underlineDraw } from "@/lib/animations";
+
+interface SectionHeadingProps {
+  title: string;
+  className?: string;
+}
+
+export function SectionHeading({ title, className }: SectionHeadingProps) {
+  return (
+    <div className={cn("mb-12", className)}>
+      <h2
+        style={{
+          fontFamily: "var(--font-pixel)",
+          fontSize: "14px",
+          color: "var(--white)",
+          letterSpacing: "0.05em",
+          marginBottom: "0.75rem",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            color: "var(--green-bright)",
+            marginRight: "0.5rem",
+          }}
+        >
+          {">_"}
+        </span>
+        {title}
+      </h2>
+      <motion.div
+        variants={underlineDraw}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        style={{
+          height: "2px",
+          background: "var(--green-primary)",
+          transformOrigin: "left",
+          width: "100%",
+          maxWidth: "200px",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/layout/SectionWrapper.tsx
+++ b/src/components/layout/SectionWrapper.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { motion } from "motion/react";
+import { cn } from "@/lib/cn";
+import { fadeInUp } from "@/lib/animations";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+interface SectionWrapperProps {
+  children: React.ReactNode;
+  className?: string;
+  id?: string;
+}
+
+export function SectionWrapper({ children, className, id }: SectionWrapperProps) {
+  const reducedMotion = useReducedMotion();
+
+  if (reducedMotion) {
+    return (
+      <section id={id} className={cn("section-padding", className)}>
+        {children}
+      </section>
+    );
+  }
+
+  return (
+    <motion.section
+      id={id}
+      className={cn("section-padding", className)}
+      variants={fadeInUp}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+    >
+      {children}
+    </motion.section>
+  );
+}

--- a/src/components/ui/GlassCard.tsx
+++ b/src/components/ui/GlassCard.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/cn";
+import { PixelBorder } from "@/components/ui/PixelBorder";
+
+interface GlassCardProps {
+  children: React.ReactNode;
+  className?: string;
+  pixelBorder?: boolean;
+}
+
+export function GlassCard({ children, className, pixelBorder }: GlassCardProps) {
+  const content = (
+    <div
+      className={cn("glass-card rounded-sm", className)}
+      style={{
+        backdropFilter: "blur(12px) saturate(180%)",
+        WebkitBackdropFilter: "blur(12px) saturate(180%)",
+        background: "rgba(17, 24, 39, 0.6)",
+        border: "1px solid rgba(255, 255, 255, 0.08)",
+        // overflow: clip is safe to use here if clipping is needed — never overflow: hidden
+      }}
+    >
+      {children}
+    </div>
+  );
+
+  if (pixelBorder) {
+    return <PixelBorder>{content}</PixelBorder>;
+  }
+
+  return content;
+}

--- a/src/components/ui/PixelBorder.tsx
+++ b/src/components/ui/PixelBorder.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/cn";
+
+interface PixelBorderProps {
+  children: React.ReactNode;
+  className?: string;
+  color?: string;
+}
+
+export function PixelBorder({ children, className, color }: PixelBorderProps) {
+  const borderColor = color ?? "var(--green-primary)";
+  const bgColor = "var(--bg-primary)";
+
+  const boxShadow = [
+    `0 -4px 0 0 ${borderColor}`,
+    `0 4px 0 0 ${borderColor}`,
+    `-4px 0 0 0 ${borderColor}`,
+    `4px 0 0 0 ${borderColor}`,
+    `-4px -4px 0 0 ${bgColor}`,
+    `4px -4px 0 0 ${bgColor}`,
+    `-4px 4px 0 0 ${bgColor}`,
+    `4px 4px 0 0 ${bgColor}`,
+  ].join(", ");
+
+  return (
+    <div
+      className={cn(className)}
+      style={{
+        boxShadow,
+        transform: "translateZ(0)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,14 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function useReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReduced(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setPrefersReduced(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return prefersReduced;
+}


### PR DESCRIPTION
## Summary
- Implements `PixelBorder` component with CSS box-shadow pixel border pattern and retina fix (`translateZ(0)`)
- Implements `GlassCard` with glassmorphism (webkit backdrop-filter for Safari, never `overflow:hidden`)
- Implements `SectionHeading` with Press Start 2P title and animated draw-in underline via `whileInView`
- Implements `SectionWrapper` with scroll-triggered `fadeInUp` and reduced-motion support
- Adds stub `useReducedMotion.ts` (full implementation comes in #2)

## Test plan
- [ ] All components compile with zero TypeScript errors
- [ ] `npx next build` passes cleanly
- [ ] Components accept `className` prop for composition
- [ ] Glass card blur works in Safari (webkit prefix present)
- [ ] Pixel border corners use `translateZ(0)` for retina

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)