### PR TITLE
feat: Hero section + NavBar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -256,3 +256,9 @@ body {
   background: rgba(0, 166, 81, 0.3);
   color: var(--green-bright);
 }
+
+/* ─── NavBar Mobile ──────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .nav-links-desktop { display: none !important; }
+  .nav-burger { display: block !important; }
+}

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { useTheme } from "@/components/providers/ThemeProvider";
+import { useScrollSection } from "@/hooks/useScrollSection";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { navSlideDown } from "@/lib/animations";
+import { navLinks } from "@/lib/data";
+import { cn } from "@/lib/cn";
+
+const SECTION_IDS = ["about", "experience", "projects", "skills", "education", "contact"];
+
+export function NavBar() {
+  const { loadingComplete } = useTheme();
+  const activeSection = useScrollSection(SECTION_IDS);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <AnimatePresence>
+      {loadingComplete && (
+        <motion.nav
+          key="navbar"
+          variants={navSlideDown}
+          initial="hidden"
+          animate="visible"
+          role="navigation"
+          aria-label="Main navigation"
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            right: 0,
+            zIndex: 100,
+            backdropFilter: "blur(12px) saturate(180%)",
+            WebkitBackdropFilter: "blur(12px) saturate(180%)",
+            background: "rgba(5, 10, 5, 0.85)",
+            borderBottom: "1px solid var(--green-muted)",
+          }}
+        >
+          <div
+            style={{
+              maxWidth: "1200px",
+              margin: "0 auto",
+              padding: "0 1.5rem",
+              height: "60px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <a
+              href="#"
+              style={{
+                fontFamily: "var(--font-pixel)",
+                fontSize: "12px",
+                color: "var(--green-primary)",
+                textDecoration: "none",
+                letterSpacing: "0.05em",
+              }}
+            >
+              S.M
+            </a>
+
+            {/* Desktop nav links */}
+            <div className="nav-links-desktop" style={{ display: "flex", gap: "2rem", alignItems: "center" }}>
+              {navLinks.map(({ label, href }) => {
+                const sectionId = href.replace("#", "");
+                const isActive = activeSection === sectionId;
+                return (
+                  <a
+                    key={label}
+                    href={href}
+                    className={cn(isActive && "pixel-border")}
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "0.8rem",
+                      color: isActive ? "var(--green-bright)" : "var(--gray-400)",
+                      textDecoration: "none",
+                      padding: isActive ? "4px 10px" : "4px 0",
+                      transition: "color 0.2s",
+                      letterSpacing: "0.05em",
+                    }}
+                  >
+                    {label}
+                  </a>
+                );
+              })}
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+              <ThemeToggle />
+              <button
+                onClick={() => setMobileOpen((o) => !o)}
+                aria-label={mobileOpen ? "Close menu" : "Open menu"}
+                className="nav-burger"
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: "var(--green-primary)",
+                  cursor: "pointer",
+                  fontFamily: "var(--font-pixel)",
+                  fontSize: "12px",
+                  padding: "4px",
+                  display: "none",
+                }}
+              >
+                {mobileOpen ? "✕" : "≡"}
+              </button>
+            </div>
+          </div>
+
+          <AnimatePresence>
+            {mobileOpen && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                style={{
+                  overflow: "hidden",
+                  background: "rgba(5, 10, 5, 0.95)",
+                  borderTop: "1px solid var(--green-muted)",
+                }}
+              >
+                <div style={{ padding: "1rem 1.5rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+                  {navLinks.map(({ label, href }) => (
+                    <a
+                      key={label}
+                      href={href}
+                      onClick={() => setMobileOpen(false)}
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.875rem",
+                        color: "var(--gray-400)",
+                        textDecoration: "none",
+                        letterSpacing: "0.05em",
+                      }}
+                    >
+                      &gt;_ {label}
+                    </a>
+                  ))}
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </motion.nav>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { motion, AnimatePresence } from "motion/react";
+import { useTheme } from "@/components/providers/ThemeProvider";
+import { letterReveal, staggerFast, fadeIn } from "@/lib/animations";
+import { heroRoles } from "@/lib/data";
+import { cn } from "@/lib/cn";
+import { useEffect, useState } from "react";
+
+// Inline typewriter (TypewriterText from #3 may not be merged into master yet)
+function useTypewriterSimple(text: string, speed = 60) {
+  const [displayed, setDisplayed] = useState("");
+  useEffect(() => {
+    setDisplayed("");
+    let i = 0;
+    const id = setInterval(() => {
+      i++;
+      setDisplayed(text.slice(0, i));
+      if (i >= text.length) clearInterval(id);
+    }, speed);
+    return () => clearInterval(id);
+  }, [text, speed]);
+  return displayed;
+}
+
+const NAME = "SUDHANVA MANJUNATH";
+const NAME_CHARS = NAME.split("");
+
+export function Hero() {
+  const { loadingComplete } = useTheme();
+  const [roleIndex, setRoleIndex] = useState(0);
+  const displayedRole = useTypewriterSimple(heroRoles[roleIndex], 60);
+
+  useEffect(() => {
+    if (displayedRole === heroRoles[roleIndex]) {
+      const t = setTimeout(() => setRoleIndex((i) => (i + 1) % heroRoles.length), 1800);
+      return () => clearTimeout(t);
+    }
+  }, [displayedRole, roleIndex]);
+
+  return (
+    <section
+      id="hero"
+      className={cn("hero-grid")}
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        position: "relative",
+        padding: "0 1.5rem",
+      }}
+    >
+      <AnimatePresence>
+        {loadingComplete && (
+          <motion.div
+            key="hero-content"
+            initial="hidden"
+            animate="visible"
+            variants={fadeIn}
+            style={{ textAlign: "center", maxWidth: "900px", width: "100%" }}
+          >
+            {/* Name with letter stagger */}
+            <motion.div
+              variants={staggerFast}
+              initial="hidden"
+              animate="visible"
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                justifyContent: "center",
+                gap: "0",
+                marginBottom: "1.5rem",
+                perspective: "400px",
+              }}
+            >
+              {NAME_CHARS.map((char, i) => (
+                <motion.span
+                  key={i}
+                  variants={letterReveal}
+                  style={{
+                    fontFamily: "var(--font-pixel)",
+                    fontSize: "clamp(10px, 2.5vw, 16px)",
+                    color: "var(--white)",
+                    display: "inline-block",
+                    whiteSpace: char === " " ? "pre" : "normal",
+                    padding: char === " " ? "0 0.2em" : "0",
+                    lineHeight: 1.4,
+                    letterSpacing: "0.05em",
+                  }}
+                >
+                  {char}
+                </motion.span>
+              ))}
+            </motion.div>
+
+            {/* Typewriter subtitle */}
+            <motion.div variants={fadeIn} style={{ marginBottom: "2.5rem" }}>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "clamp(0.875rem, 2vw, 1.125rem)",
+                  color: "var(--green-bright)",
+                }}
+              >
+                {displayedRole}
+                <span className="cursor-blink" style={{ marginLeft: "2px" }}>▋</span>
+              </span>
+            </motion.div>
+
+            {/* CTA buttons */}
+            <motion.div
+              variants={fadeIn}
+              style={{ display: "flex", gap: "1.5rem", justifyContent: "center", flexWrap: "wrap" }}
+            >
+              <a
+                href="#projects"
+                className="pixel-border"
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.875rem",
+                  color: "var(--green-primary)",
+                  padding: "0.75rem 1.5rem",
+                  background: "transparent",
+                  textDecoration: "none",
+                  display: "inline-block",
+                  transition: "color 0.2s, background 0.2s",
+                }}
+              >
+                View Work
+              </a>
+              <a
+                href="/resume.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.875rem",
+                  color: "var(--gray-400)",
+                  padding: "0.75rem 1.5rem",
+                  border: "1px solid var(--gray-700, #3a3a3c)",
+                  textDecoration: "none",
+                  display: "inline-block",
+                }}
+              >
+                Resume ↗
+              </a>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Scroll indicator */}
+      {loadingComplete && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.5 }}
+          style={{
+            position: "absolute",
+            bottom: "2rem",
+            left: "50%",
+            transform: "translateX(-50%)",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "4px",
+          }}
+        >
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "var(--gray-400)", letterSpacing: "0.1em" }}>
+            SCROLL
+          </span>
+          <motion.div
+            animate={{ y: [0, 6, 0] }}
+            transition={{ duration: 1.5, repeat: Infinity, ease: "easeInOut" }}
+            style={{ color: "var(--green-primary)", fontSize: "1rem" }}
+          >
+            ↓
+          </motion.div>
+        </motion.div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- `Hero`: full-viewport with letter-stagger "SUDHANVA MANJUNATH" reveal, cycling typewriter subtitle, pixel-bordered CTA buttons, `.hero-grid` animated background, bounce scroll indicator
- `NavBar`: sticky glass nav with S.M wordmark, `useScrollSection` active tracking, `ThemeToggle`, mobile hamburger with `AnimatePresence` dropdown
- Both conditionally render after `loadingComplete === true` via `AnimatePresence`

## Screenshot Testing
2-pass at port 3005. Pass 1 caught oversized word-space between name words — fixed to `0.2em`. Pass 2 confirmed: NavBar chrome, hero layout, grid background, typewriter, dark palette all correct.

## Test plan
- [ ] Letter stagger animation plays after loadingComplete
- [ ] Typewriter cycles through all heroRoles
- [ ] NavBar slides down only after loadingComplete
- [ ] Active section highlight updates on scroll
- [ ] Mobile nav works at 375px
- [ ] `npx next build` passes with zero TypeScript errors

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)