### PR TITLE
feat(issue-8): Education + Contact sections + final page assembly

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import { AnimatePresence } from "motion/react";
-import { LoadingScreen } from "@/components/sections/LoadingScreen";
 import { useTheme } from "@/components/providers/ThemeProvider";
+import { LoadingScreen } from "@/components/sections/LoadingScreen";
 import { NavBar } from "@/components/layout/NavBar";
 import { Hero } from "@/components/sections/Hero";
+import { About } from "@/components/sections/About";
+import { Experience } from "@/components/sections/Experience";
+import { Projects } from "@/components/sections/Projects";
+import { Skills } from "@/components/sections/Skills";
+import { Education } from "@/components/sections/Education";
+import { Contact } from "@/components/sections/Contact";
 
 export default function Home() {
   const { loadingComplete, setLoadingComplete } = useTheme();
@@ -22,7 +28,15 @@ export default function Home() {
       {loadingComplete && (
         <>
           <NavBar />
-          <Hero />
+          <main>
+            <Hero />
+            <About />
+            <Experience />
+            <Projects />
+            <Skills />
+            <Education />
+            <Contact />
+          </main>
         </>
       )}
     </>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { motion } from "motion/react";
+import { SectionWrapper } from "@/components/layout/SectionWrapper";
+import { SectionHeading } from "@/components/layout/SectionHeading";
+import { fadeInUp, staggerContainer } from "@/lib/animations";
+import { contactLinks } from "@/lib/data";
+
+export function Contact() {
+  return (
+    <SectionWrapper id="contact">
+      <div style={{ maxWidth: "800px", margin: "0 auto", padding: "0 1.5rem" }}>
+        <SectionHeading title="contact" />
+
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "3rem", marginTop: "3rem" }}>
+          {/* Terminal window */}
+          <div
+            style={{
+              width: "100%",
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--green-muted)",
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            {/* Terminal header */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "6px",
+                padding: "10px 14px",
+                borderBottom: "1px solid var(--green-muted)",
+                background: "rgba(0, 166, 81, 0.05)",
+              }}
+            >
+              {(["#ff5f57", "#ffbd2e", "#28c840"] as const).map((color, i) => (
+                <span
+                  key={i}
+                  style={{
+                    display: "inline-block",
+                    width: "8px",
+                    height: "8px",
+                    background: color,
+                    borderRadius: "50%",
+                    opacity: 0.8,
+                  }}
+                />
+              ))}
+              <span
+                style={{
+                  marginLeft: "auto",
+                  color: "var(--gray-400)",
+                  fontSize: "0.75rem",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                contact.sh
+              </span>
+            </div>
+
+            {/* Terminal body */}
+            <div style={{ padding: "1.5rem 1.25rem" }}>
+              {/* Shell invocation line */}
+              <motion.div
+                variants={fadeInUp}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.875rem",
+                  color: "var(--green-bright)",
+                  marginBottom: "1rem",
+                }}
+              >
+                $ ./contact.sh
+              </motion.div>
+
+              {/* Available channels label */}
+              <motion.div
+                variants={fadeInUp}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.875rem",
+                  color: "var(--gray-400)",
+                  marginBottom: "0.75rem",
+                }}
+              >
+                &gt; Available channels:
+              </motion.div>
+
+              {/* Contact links — staggered */}
+              <motion.div
+                variants={staggerContainer}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                style={{ display: "flex", flexDirection: "column", gap: "0.6rem" }}
+              >
+                {contactLinks.map((link) => (
+                  <motion.div key={link.label} variants={fadeInUp}>
+                    <a
+                      href={link.href}
+                      target={link.href.startsWith("mailto:") || link.href.startsWith("tel:") ? "_self" : "_blank"}
+                      rel="noopener noreferrer"
+                      className="contact-link"
+                      style={{
+                        display: "flex",
+                        alignItems: "baseline",
+                        gap: "0.75rem",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.875rem",
+                        color: "var(--white)",
+                        textDecoration: "none",
+                        transition: "color 0.2s, text-shadow 0.2s",
+                        lineHeight: 1.6,
+                      }}
+                    >
+                      <span style={{ color: "var(--gray-400)", minWidth: "1rem", textAlign: "center" }}>
+                        &gt;
+                      </span>
+                      <span style={{ color: "var(--green-primary)", minWidth: "1rem" }}>
+                        {link.icon}
+                      </span>
+                      <span
+                        style={{
+                          color: "var(--gray-400)",
+                          minWidth: "5.5rem",
+                          display: "inline-block",
+                        }}
+                      >
+                        {link.label}
+                      </span>
+                      <span style={{ color: "var(--white)" }}>
+                        {link.value}
+                      </span>
+                    </a>
+                  </motion.div>
+                ))}
+              </motion.div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <p
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.75rem",
+              color: "var(--gray-400)",
+              textAlign: "center",
+              margin: 0,
+              letterSpacing: "0.03em",
+            }}
+          >
+            Built with Next.js + motion + ♥
+          </p>
+        </div>
+      </div>
+
+      <style>{`
+        .contact-link:hover {
+          color: var(--green-primary) !important;
+          text-shadow: 0 0 8px rgba(0, 166, 81, 0.6);
+        }
+        .contact-link:hover span {
+          color: var(--green-primary) !important;
+        }
+      `}</style>
+    </SectionWrapper>
+  );
+}

--- a/src/components/sections/Education.tsx
+++ b/src/components/sections/Education.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { motion } from "motion/react";
+import { SectionWrapper } from "@/components/layout/SectionWrapper";
+import { SectionHeading } from "@/components/layout/SectionHeading";
+import { GlassCard } from "@/components/ui/GlassCard";
+import { fadeInUp, staggerContainer } from "@/lib/animations";
+import { education } from "@/lib/data";
+
+export function Education() {
+  return (
+    <SectionWrapper id="education">
+      <div style={{ maxWidth: "1200px", margin: "0 auto", padding: "0 1.5rem" }}>
+        <SectionHeading title="education" />
+
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            gap: "1.5rem",
+            marginTop: "3rem",
+          }}
+          className="education-grid"
+        >
+          {education.map((edu) => (
+            <motion.div key={edu.id} variants={fadeInUp}>
+              <GlassCard pixelBorder>
+                <div style={{ padding: "1.5rem" }}>
+                  {/* Institution name */}
+                  <h3
+                    style={{
+                      fontFamily: "var(--font-sans)",
+                      fontWeight: 600,
+                      fontSize: "1.1rem",
+                      color: "var(--white)",
+                      margin: "0 0 0.5rem",
+                      lineHeight: 1.3,
+                    }}
+                  >
+                    {edu.institution}
+                  </h3>
+
+                  {/* Degree */}
+                  <p
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "0.875rem",
+                      color: "var(--green-primary)",
+                      margin: "0 0 1rem",
+                    }}
+                  >
+                    {edu.degree}
+                  </p>
+
+                  {/* Meta row: period, location, CGPA badge */}
+                  <div
+                    style={{
+                      display: "flex",
+                      flexWrap: "wrap",
+                      alignItems: "center",
+                      gap: "0.75rem",
+                      marginBottom: "1.25rem",
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.75rem",
+                        color: "var(--gray-400)",
+                      }}
+                    >
+                      {edu.period}
+                    </span>
+                    <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.7rem", color: "var(--gray-400)" }}>·</span>
+                    <span
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.75rem",
+                        color: "var(--gray-400)",
+                      }}
+                    >
+                      {edu.location}
+                    </span>
+                    {/* CGPA badge */}
+                    <span
+                      className="pixel-border"
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.7rem",
+                        color: "var(--green-primary)",
+                        padding: "2px 8px",
+                        marginLeft: "auto",
+                        whiteSpace: "nowrap",
+                        transform: "translateZ(0)",
+                      }}
+                    >
+                      GPA {edu.cgpa}
+                    </span>
+                  </div>
+
+                  {/* Coursework tags */}
+                  {edu.coursework.length > 0 && (
+                    <div>
+                      <p
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.65rem",
+                          color: "var(--gray-400)",
+                          letterSpacing: "0.12em",
+                          textTransform: "uppercase",
+                          margin: "0 0 0.5rem",
+                        }}
+                      >
+                        Coursework
+                      </p>
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
+                        {edu.coursework.map((course) => (
+                          <span
+                            key={course}
+                            className="pixel-border"
+                            style={{
+                              fontFamily: "var(--font-mono)",
+                              fontSize: "0.65rem",
+                              color: "var(--green-muted)",
+                              padding: "3px 8px",
+                              letterSpacing: "0.03em",
+                              transform: "translateZ(0)",
+                            }}
+                          >
+                            {course}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </GlassCard>
+            </motion.div>
+          ))}
+        </motion.div>
+      </div>
+
+      <style>{`
+        @media (min-width: 768px) {
+          .education-grid { grid-template-columns: 1fr 1fr !important; }
+        }
+      `}</style>
+    </SectionWrapper>
+  );
+}


### PR DESCRIPTION
## Summary\n- Builds Education section with Apple-style GlassCards in a 2-col responsive grid, featuring institution name (Inter semi-bold), degree (JetBrains Mono), CGPA pixel-border badge, period/location in gray-400, and coursework tags with muted green pixel borders; fadeInUp animations via staggerContainer whileInView\n- Builds Contact section with a custom TerminalWindow (title: contact.sh) showing the shell invocation line, "Available channels" header, and all 4 contact links (Email, LinkedIn, GitHub, Phone) with sequential stagger entrance and green glow hover effect; footer "Built with Next.js + motion + ♥"\n- Assembles final page.tsx with all 8 sections in correct order (LoadingScreen, NavBar, Hero, About, Experience, Projects, Skills, Education, Contact) with AnimatePresence wrapping the LoadingScreen conditional render\n\n## Test plan\n- [ ] Education cards show correct content for both institutions (CU Boulder + PES University)\n- [ ] CGPA badge (pixel-border, green) renders on each card\n- [ ] Coursework tags display with muted-green pixel borders\n- [ ] 2-column grid on desktop, stacked on mobile\n- [ ] Contact terminal shows all 4 links with correct labels, icons, and values\n- [ ] Contact links are all functional anchor tags\n- [ ] Footer "Built with Next.js + motion + ♥" is present and styled\n- [ ] Green glow hover effect on contact links\n- [ ] page.tsx assembles all sections in correct order\n- [ ] AnimatePresence correctly handles LoadingScreen exit\n- [ ] Background is near-black (#050a05)\n- [ ] No TypeScript errors (npx tsc --noEmit passes)\n- [ ] Production build passes cleanly (npx next build)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)