### PR TITLE
redesign R10: NavBar fix, cursor removal, accent cleanup

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,7 +14,7 @@
   --text-muted: #888078;
   --text-faint: #b8b0a8;
   --border: #e8e0d8;
-  --accent: #00a651;
+  --accent: #0d0c0b;
 
   /* For backdrop-filter rgba usage */
   --bg-rgb: 250, 250, 248;
@@ -27,7 +27,7 @@
   --text-muted: #7a7068;
   --text-faint: #4a4440;
   --border: #2a2520;
-  --accent: #00a651;
+  --accent: #f0ede8;
   --bg-rgb: 13, 12, 11;
 }
 
@@ -45,7 +45,7 @@ body {
   background-color: var(--bg);
   color: var(--text);
   font-family: var(--font-sans), system-ui, sans-serif;
-  cursor: none; /* custom cursor */
+  cursor: auto;
   transition: background-color 0.3s ease, color 0.3s ease;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -83,7 +83,6 @@ body {
   text-decoration: none;
   letter-spacing: 0.01em;
   transition: letter-spacing 200ms ease, color 200ms ease;
-  cursor: none;
 }
 
 .nav-link:hover {
@@ -95,7 +94,6 @@ body {
 .draw-underline {
   position: relative;
   text-decoration: none;
-  cursor: none;
 }
 
 .draw-underline::after {
@@ -121,7 +119,7 @@ body {
   border-left: 2px solid transparent;
   padding-left: 0;
   transition: background-color 150ms ease, border-left-color 150ms ease, padding-left 150ms ease;
-  cursor: none;
+  cursor: default;
 }
 
 .work-row:hover {
@@ -130,7 +128,3 @@ body {
   padding-left: 12px;
 }
 
-/* Magnetic button cursor */
-a, button, [role="button"] {
-  cursor: none;
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,6 @@ import { Projects } from "@/components/sections/Projects";
 import { Skills } from "@/components/sections/Skills";
 import { Education } from "@/components/sections/Education";
 import { Contact } from "@/components/sections/Contact";
-import { CustomCursor } from "@/components/ui/CustomCursor";
 import { ScrollProgressBar } from "@/components/ui/ScrollProgressBar";
 
 export default function Home() {
@@ -19,7 +18,6 @@ export default function Home() {
 
   return (
     <>
-      <CustomCursor />
       <ScrollProgressBar />
       <AnimatePresence mode="wait">
         {!loadingComplete && (

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,108 +1,98 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { ThemeToggle } from "@/components/ui/ThemeToggle";
+"use client"
+import { useState, useEffect } from "react"
+import { motion, AnimatePresence } from "motion/react"
+import { ThemeToggle } from "@/components/ui/ThemeToggle"
+import Link from "next/link"
 
 export function NavBar() {
-  const [scrolled, setScrolled] = useState(false);
+  const [scrolled, setScrolled] = useState(false)
 
   useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 80);
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
+    const onScroll = () => setScrolled(window.scrollY > 80)
+    window.addEventListener("scroll", onScroll, { passive: true })
+    onScroll()
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [])
 
   const navLinks = [
-    { label: "About", href: "#about" },
-    { label: "Work", href: "#experience" },
+    { label: "About", href: "/about" },
+    { label: "Work", href: "/work" },
     { label: "Contact", href: "mailto:sudhanva.m@icloud.com" },
-  ];
-
-  if (!scrolled) {
-    return (
-      <nav
-        style={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          right: 0,
-          padding: "20px 32px",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          zIndex: 1000,
-          transition: "all 400ms cubic-bezier(0.22, 1, 0.36, 1)",
-        }}
-      >
-        <span
-          style={{
-            fontFamily: "var(--font-sans)",
-            fontSize: "15px",
-            color: "var(--text)",
-          }}
-        >
-          Sudhanva Manjunath
-        </span>
-        <div
-          style={{ display: "flex", alignItems: "center", gap: "28px" }}
-        >
-          {navLinks.map((link) => (
-            <a
-              key={link.label}
-              href={link.href}
-              className="nav-link"
-            >
-              {link.label}
-            </a>
-          ))}
-          <ThemeToggle />
-        </div>
-      </nav>
-    );
-  }
+  ]
 
   return (
-    <nav
+    // Fixed full-width anchor — transparent, pointer-events:none so it doesn't block page clicks
+    <div
       style={{
         position: "fixed",
-        top: "16px",
-        left: "50%",
-        transform: "translateX(-50%)",
-        padding: "10px 20px",
-        display: "flex",
-        alignItems: "center",
-        gap: "20px",
+        top: 0,
+        left: 0,
+        right: 0,
         zIndex: 1000,
-        borderRadius: "9999px",
-        background: "rgba(13,12,11,0.88)",
-        backdropFilter: "blur(12px)",
-        WebkitBackdropFilter: "blur(12px)",
-        border: "1px solid var(--border)",
-        transition: "all 400ms cubic-bezier(0.22, 1, 0.36, 1)",
-        whiteSpace: "nowrap",
+        display: "flex",
+        justifyContent: scrolled ? "center" : "flex-end",
+        padding: scrolled ? "0" : "20px 32px",
+        pointerEvents: "none",
       }}
     >
-      <span
+      <motion.nav
+        layout
+        transition={{
+          layout: { type: "spring", stiffness: 260, damping: 28, mass: 0.9 },
+        }}
         style={{
-          fontFamily: "var(--font-sans)",
-          fontSize: "14px",
-          fontWeight: 600,
-          color: "var(--accent)",
-          marginRight: "8px",
+          pointerEvents: "auto",
+          marginTop: scrolled ? "16px" : "0",
+          padding: scrolled ? "10px 20px" : "0",
+          borderRadius: scrolled ? "9999px" : "0px",
+          background: scrolled ? `rgba(var(--bg-rgb), 0.92)` : "transparent",
+          backdropFilter: scrolled ? "blur(12px)" : "none",
+          WebkitBackdropFilter: scrolled ? "blur(12px)" : "none",
+          border: scrolled ? "1px solid var(--border)" : "1px solid transparent",
+          display: "flex",
+          alignItems: "center",
+          gap: "20px",
+          whiteSpace: "nowrap",
         }}
       >
-        SM
-      </span>
-      {navLinks.map((link) => (
-        <a
-          key={link.label}
-          href={link.href}
-          className="nav-link"
-        >
-          {link.label}
-        </a>
-      ))}
-      <ThemeToggle />
-    </nav>
-  );
+        {/* SM — fades in when pill is active. Same element, not a swap. */}
+        <AnimatePresence>
+          {scrolled && (
+            <motion.span
+              key="sm-label"
+              initial={{ opacity: 0, width: 0 }}
+              animate={{ opacity: 1, width: "auto" }}
+              exit={{ opacity: 0, width: 0 }}
+              transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "13px",
+                fontWeight: 600,
+                color: "var(--text)",
+                overflow: "hidden",
+                display: "inline-block",
+                paddingRight: "4px",
+              }}
+            >
+              SM
+            </motion.span>
+          )}
+        </AnimatePresence>
+
+        {/* Nav links — always present */}
+        {navLinks.map((link) => (
+          <Link
+            key={link.label}
+            href={link.href}
+            className="nav-link"
+            style={{ fontSize: "13px" }}
+          >
+            {link.label}
+          </Link>
+        ))}
+
+        <ThemeToggle />
+      </motion.nav>
+    </div>
+  )
 }

--- a/src/components/ui/ScrollProgressBar.tsx
+++ b/src/components/ui/ScrollProgressBar.tsx
@@ -20,7 +20,7 @@ export function ScrollProgressBar() {
       <motion.div
         style={{
           height: "100%",
-          background: "var(--accent)",
+          background: "var(--text-faint)",
           width,
           transformOrigin: "left",
         }}


### PR DESCRIPTION
## Summary

- **NavBar rewrite**: Single `motion.nav` with Framer Motion `layout` prop for smooth FLIP animation between right-aligned (full) and centered (pill) states
- **Removed**: "Sudhanva Manjunath" from navbar left side (redundant — hero shows it)
- **SM animation**: Appears inside the existing pill via `AnimatePresence` — same element morphing, not a hard swap
- **Theme-aware background**: `rgba(var(--bg-rgb), 0.92)` works correctly in both light and dark modes
- **Removed**: CustomCursor from page.tsx
- **Cursor styles**: Reset `cursor: none` to auto/default in globals.css
- **Accent color**: Changed from green `#00a651` to neutral (text color) in both themes
- **ScrollProgressBar**: Changed to `var(--text-faint)` color

## Test plan
- [ ] Nav shows only right-aligned links before scroll (no name on left)
- [ ] Scrolling morphs nav into centered pill smoothly from right→center
- [ ] SM appears in pill as part of animation (not a hard swap)
- [ ] Pill background works in both light and dark mode
- [ ] No green accent anywhere on page
- [ ] Custom cursor not shown (normal OS cursor)
- [ ] `npx next build` passes

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)