### PR TITLE
redesign R11: Full-screen loader + Hero font fixes

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,18 +1,15 @@
 "use client"
-
 import { useRef } from "react"
 import { motion, useScroll, useTransform } from "motion/react"
+
+// Must match LoadingScreen.tsx NAME_FONT_SIZE
+const NAME_FONT_SIZE = 36 // px
 
 export function Hero() {
   const containerRef = useRef<HTMLElement>(null)
   const { scrollY } = useScroll()
-  const nameY = useTransform(scrollY, [0, 400], [0, -40])
-  const subtitleY = useTransform(scrollY, [0, 400], [0, -20])
-
-  const blurFade = {
-    initial: { opacity: 0, filter: "blur(8px)", y: 20 },
-    animate: { opacity: 1, filter: "blur(0px)", y: 0 },
-  }
+  const nameY = useTransform(scrollY, [0, 400], [0, -30])
+  const subtitleY = useTransform(scrollY, [0, 400], [0, -15])
 
   return (
     <section
@@ -30,55 +27,63 @@ export function Hero() {
         width: "100%",
       }}
     >
+      {/* "Hello, I'm" — animates AFTER name */}
+      <motion.p
+        style={{
+          fontFamily: "var(--font-sans)",
+          fontSize: "13px",
+          color: "var(--text-muted)",
+          marginBottom: "10px",
+          letterSpacing: "0.02em",
+        }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, delay: 0.4 }}
+      >
+        Hello, I&apos;m
+      </motion.p>
+
+      {/* Name — opacity only (no blur/translate) for seamless loader hand-off */}
       <motion.h1
         style={{
           fontFamily: "var(--font-serif)",
-          fontSize: "clamp(40px, 8vw, 88px)",
+          fontSize: `${NAME_FONT_SIZE}px`,
           color: "var(--text)",
           lineHeight: 1.1,
-          marginBottom: "24px",
+          marginBottom: "20px",
           fontWeight: 400,
           y: nameY,
         }}
-        {...blurFade}
-        transition={{ duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.3, ease: "easeOut" }}
       >
         Sudhanva Manjunath
       </motion.h1>
 
+      {/* Subtitle — serif as user requested */}
       <motion.p
         style={{
-          fontFamily: "var(--font-sans)",
+          fontFamily: "var(--font-serif)",
           fontSize: "18px",
           color: "var(--text-muted)",
-          lineHeight: 1.6,
-          maxWidth: "480px",
-          marginBottom: "16px",
+          lineHeight: 1.65,
+          maxWidth: "420px",
+          marginBottom: "48px",
           y: subtitleY,
         }}
-        {...blurFade}
-        transition={{ duration: 0.8, delay: 0.3, ease: [0.22, 1, 0.36, 1] }}
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.5, ease: [0.22, 1, 0.36, 1] }}
       >
-        Software engineer building thoughtful systems at the intersection of UX and engineering.
+        an engineer who bridges UX and engineering.
       </motion.p>
 
-      <motion.p
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: "13px",
-          color: "var(--text-faint)",
-          marginBottom: "48px",
-        }}
-        {...blurFade}
-        transition={{ duration: 0.8, delay: 0.5, ease: [0.22, 1, 0.36, 1] }}
-      >
-        MS CS @ CU Boulder · Boulder, CO
-      </motion.p>
-
+      {/* Bouncing arrow */}
       <motion.div
         animate={{ y: [0, 8, 0] }}
         transition={{ duration: 1.5, repeat: Infinity, ease: "easeInOut" }}
-        style={{ color: "var(--text-faint)", fontSize: "20px" }}
+        style={{ color: "var(--text-faint)", fontSize: "18px" }}
       >
         ↓
       </motion.div>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -43,8 +43,14 @@ export function Hero() {
         Hello, I&apos;m
       </motion.p>
 
-      {/* Name — opacity only (no blur/translate) for seamless loader hand-off */}
+      {/*
+        Name — layoutId="hero-name" creates a shared element transition with the
+        LoadingScreen's name element. When the loading screen unmounts, Framer Motion
+        records its position and springs this h1 from there to its actual position.
+        No explicit initial/animate needed — layoutId handles the entrance.
+      */}
       <motion.h1
+        layoutId="hero-name"
         style={{
           fontFamily: "var(--font-serif)",
           fontSize: `${NAME_FONT_SIZE}px`,
@@ -54,9 +60,6 @@ export function Hero() {
           fontWeight: 400,
           y: nameY,
         }}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.3, ease: "easeOut" }}
       >
         Sudhanva Manjunath
       </motion.h1>


### PR DESCRIPTION
## Summary

### LoadingScreen redesign
- Full viewport filled with rapidly changing gray characters (monospace 18px grid)
- Light background (`#fafaf8`) matching site default — seamless visual hand-off to hero
- Name \"sudhanva manjunath\" scrambles initially then locks in dark serif left-to-right
- Positioned at `max(40px, calc((100vw - 900px) / 2 + 40px))` — exactly where hero h1 appears
- Background char grid fades out (0.6s) when name is complete, then `onComplete()` fires

### Hero.tsx fixes (from screenshot feedback)
- Name font size: `36px` (was `clamp(40px, 8vw, 88px)` — far too large)
- Name animate-in: **opacity only** (no blur/translate) so position matches loader exactly
- Added \"Hello, I'm\" label above name (13px sans, text-muted, 0.4s delay)
- Subtitle: **serif font** (Lora) as user requested
- Subtitle text: \"an engineer who bridges UX and engineering.\"
- Removed \"MS CS @ CU Boulder · Boulder, CO\" metadata line

## Test plan
- [ ] Hero name is moderate size (~36px), not taking up half viewport
- [ ] \"Hello, I'm\" appears above name
- [ ] Subtitle text is in serif (Lora) style
- [ ] Loading screen shows full-screen scramble on white/light background
- [ ] Name in loader locks in at same position/size as hero h1
- [ ] `npx next build` passes with zero errors

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)